### PR TITLE
fix sketch shortcut (export to hubble)

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -11,7 +11,7 @@
     {
       "name": "Export to Hubble App",
       "identifier": "hubble-export",
-      "shortcut": "cmd shift h",
+      "shortcut": "ctrl shift h",
       "script": "./hubble-export.js"
     },
     {


### PR DESCRIPTION
can't use `cmd` use `ctrl` instead

https://developer.sketch.com/plugins/plugin-manifest

<img width="556" alt="Screenshot 2019-05-27 at 13 49 18" src="https://user-images.githubusercontent.com/26312687/58418126-2e76f900-8087-11e9-8072-f497bd2f0be4.png">
